### PR TITLE
NullPointerException on Android 4.3 (binding:selectedObject on AdapterView)

### DIFF
--- a/Core/AndroidBinding/src/gueei/binding/viewAttributes/adapterView/SelectedObjectViewAttribute.java
+++ b/Core/AndroidBinding/src/gueei/binding/viewAttributes/adapterView/SelectedObjectViewAttribute.java
@@ -19,7 +19,7 @@ public class SelectedObjectViewAttribute extends ViewAttribute<AdapterView<?>, O
 
 	@Override
 	protected void doSetAttributeValue(Object newValue) {	
-		if(getView()==null) return;
+		if(getView()==null || getView().getAdapter()==null) return;
 		Object selected = getView().getSelectedItem();
 		Object o=null;
 		


### PR DESCRIPTION
NullPointerException on Android 4.3 if

"binding:itemSource="" and "binding:selectedObject=""

are used together on an AdapterView.
