### PR TITLE
Android Annotations support - inflate view from existing view

### DIFF
--- a/Core/AndroidBinding/src/gueei/binding/Binder.java
+++ b/Core/AndroidBinding/src/gueei/binding/Binder.java
@@ -48,6 +48,10 @@ public class Binder {
 	public static InflateResult inflateView(Context context, int layoutId, ViewGroup parent, boolean attachToRoot){
 		return _kernel.inflateView(context, layoutId, parent, attachToRoot);
 	}
+
+    public static InflateResult inflateViewFromExistingView(Context context, View view, int layoutId){
+        return _kernel.inflateViewFromExistingView(context, view, layoutId);
+    }
 	
 	public static View bindView(Context context, InflateResult inflatedView, Object model){
 		return _kernel.bindView(context, inflatedView, model);

--- a/Core/AndroidBinding/src/gueei/binding/IKernel.java
+++ b/Core/AndroidBinding/src/gueei/binding/IKernel.java
@@ -40,7 +40,17 @@ public interface IKernel {
 	 * @return Inflate Result. 
 	 */
 	public InflateResult inflateView(Context context, int layoutId, ViewGroup parent, boolean attachToRoot);
-	/**
+
+    /**
+     * Inflate, and parse the binding information with Android binding
+     * @param context
+     * @param view inflate from this view instance
+     * @param layoutId The xml layout definition (it's not INFLATED FROM this definition)
+     * @return Inflate Result.
+     */
+    public InflateResult inflateViewFromExistingView(Context context,  View view, int layoutId);
+
+    /**
 	 * Returns the binded root view of the inflated view
 	 * @param context
 	 * @param inflatedView The inflated result from inflateView


### PR DESCRIPTION
I wanted to be able to use AndroidBinding when binding to an existing view. I use it in Android Annotations where view is constructed automatically with @EActivity(R.layout.activity_init).
Later I reuse my created view  @AfterViews  protected void afterViews() {}  method.

It can be used in @AfterViews method

@AfterViews
protected void afterViews() {
   Binder.InflateResult inflateResult = Binder.inflateViewFromExistingView(this, findViewById(R.id.drawer_layout), R.layout.activity_init);
   Binder.bindView(this, inflateResult, mViewModel);
}
