### PR TITLE
added Android Spinner support with SpinnerViewProvider

### DIFF
--- a/Core/AndroidBinding/src/gueei/binding/Attribute.java
+++ b/Core/AndroidBinding/src/gueei/binding/Attribute.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import android.content.Context;
+import gueei.binding.collections.SpecificTypedObservable;
 
 public abstract class Attribute<Th, T> extends Observable<T> {
 	
@@ -74,8 +75,12 @@ public abstract class Attribute<Th, T> extends Observable<T> {
 		// So, it assumes two way no matter what
 		if (prop instanceof Undetermined)
 			binding = BindingType.TwoWay;
-		else
-			binding = AcceptThisTypeAs(prop.getType());
+		else {
+            if (prop instanceof SpecificTypedObservable)
+                binding = AcceptThisTypeAs(prop.getType(), ((SpecificTypedObservable) prop).getSpecificType());
+            else
+                binding = AcceptThisTypeAs(prop.getType());
+        }
 		
 		if (binding.equals(BindingType.NoBinding)) return binding;
 		
@@ -98,10 +103,16 @@ public abstract class Attribute<Th, T> extends Observable<T> {
 		// Broadcast initial change
 		notifyChanged(initiators);		
 	}
-	
-	protected BindingType AcceptThisTypeAs(Class<?> type){
-		if (this.getType() != type){
-			if (this.getType().isAssignableFrom(type)){
+
+    protected BindingType AcceptThisTypeAs(Class<?> type) {
+       return AcceptThisTypeAs(type, null);
+    }
+
+	protected BindingType AcceptThisTypeAs(Class<?> type, Class<?> specificType){
+		if (this.getType() != type && this.getType() != specificType){
+            boolean isAssignableFromSpecificType = specificType == null ?
+                    false : this.getType().isAssignableFrom(specificType);
+			if (this.getType().isAssignableFrom(type) || isAssignableFromSpecificType){
 				return BindingType.OneWay;
 			}
 			return BindingType.NoBinding;

--- a/Core/AndroidBinding/src/gueei/binding/collections/ArrayListObservable.java
+++ b/Core/AndroidBinding/src/gueei/binding/collections/ArrayListObservable.java
@@ -12,10 +12,11 @@ import java.util.ListIterator;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import gueei.binding.IObservableCollection;
 
 public class ArrayListObservable<T> 
 	extends ObservableCollection<T> 
-	implements List<T>, Parcelable{
+	implements List<T>, SpecificTypedObservable , Parcelable{
 	
 	private final Class<T> mType;
 	protected ArrayList<T> mArray;
@@ -34,6 +35,10 @@ public class ArrayListObservable<T>
 			}
 		}
 	}
+
+    public Class<ArrayListObservable> getSpecificType() {
+        return ArrayListObservable.class;
+    }
 	
 	public T getItem(int position) {
 		return mArray.get(position);

--- a/Core/AndroidBinding/src/gueei/binding/kernel/DefaultKernel.java
+++ b/Core/AndroidBinding/src/gueei/binding/kernel/DefaultKernel.java
@@ -18,6 +18,7 @@ public class DefaultKernel extends KernelBase  {
 		attrBinder.registerProvider(new ImageViewProvider());
 		attrBinder.registerProvider(new ExpandableListViewProvider());
 		attrBinder.registerProvider(new AbsSpinnerViewProvider());
+        attrBinder.registerProvider(new SpinnerViewProvider());
 		attrBinder.registerProvider(new ListViewProvider());
 		attrBinder.registerProvider(new AdapterViewProvider());
 		attrBinder.registerProvider(new AutoCompleteTextViewProvider());


### PR DESCRIPTION
I added Spinner "entries" property support as I wanted to be able to give entries for a Spinner from my ViewModels. 

ViewModel:

 public IObservableCollection<String> testList = new ArrayListObservable<String>(
            String.class,
            new String[] {new String("A"), new String("C")}
    );

View:

 <Spinner android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/testListSpinner"
             binding:entries="testList" ></Spinner>
